### PR TITLE
Convert build-playground/integration-tests/yaml/step_param_under_job_and_stage to GitHub Actions

### DIFF
--- a/.github/actions/integration_tests_templates_step_template_step_parameter/action.yml
+++ b/.github/actions/integration_tests_templates_step_template_step_parameter/action.yml
@@ -1,0 +1,15 @@
+name: integration_tests_templates_step_template_step_parameter
+inputs:
+  message:
+    required: false
+    default: "...."
+    type: string
+runs:
+  using: composite
+  steps:
+  - run: echo "first template step"
+    shell: bash
+  - run: echo "${{ inputs.message }}"
+    shell: bash
+  - run: echo "last template step"
+    shell: bash


### PR DESCRIPTION
Pipeline migrated from [Azure DevOps](https://dev.azure.com/valet-testing/build-playground/_build?definitionId=353) :tada: